### PR TITLE
Replace `routing_key` method support with more flexible `message_options`

### DIFF
--- a/lib/advanced_sneakers_activejob/active_job_patch.rb
+++ b/lib/advanced_sneakers_activejob/active_job_patch.rb
@@ -7,6 +7,8 @@ module AdvancedSneakersActiveJob
     included do
       # AMQP message contains metadata which might be helpful for consumer (e.g. job.delivery_info.routing_key)
       attr_accessor :delivery_info, :headers
+
+      class_attribute :publish_options, instance_accessor: false
     end
 
     module ClassMethods
@@ -20,6 +22,12 @@ module AdvancedSneakersActiveJob
       def queue_as(*args)
         super(*args)
         define_consumer
+      end
+
+      def message_options(options)
+        raise ArgumentError, 'message_options accepts Hash argument only' unless options.is_a?(Hash)
+
+        self.publish_options = options.symbolize_keys
       end
 
       private

--- a/lib/advanced_sneakers_activejob/publisher.rb
+++ b/lib/advanced_sneakers_activejob/publisher.rb
@@ -20,7 +20,7 @@ module AdvancedSneakersActiveJob
       at_exit { wait_for_unrouted_messages_processing(timeout: WAIT_FOR_UNROUTED_MESSAGES_AT_EXIT_TIMEOUT) }
     end
 
-    def publish(message, routing_key:, headers: {}, **properties)
+    def publish(message, routing_key: nil, headers: {}, **properties)
       ensure_connection!
 
       logger.debug "Publishing <#{message}> to [#{publish_exchange.name}] with routing_key [#{routing_key}]"
@@ -35,7 +35,7 @@ module AdvancedSneakersActiveJob
       publish_exchange.publish(message, params)
     end
 
-    def publish_delayed(message, routing_key:, delay:, headers: {}, **properties)
+    def publish_delayed(message, delay:, routing_key: nil, headers: {}, **properties)
       ensure_connection!
 
       logger.debug "Publishing <#{message}> to [#{publish_delayed_exchange.name}] with routing_key [#{routing_key}] and delay [#{delay}]"


### PR DESCRIPTION
Previous implementation supports custom routing key only and also makes class look strange (it might be not obvious why there is a `routing_key` method)
```ruby
class MyJob < ActiveJob::Base
  queue_as :some_name

  def perform(params)
    ProcessData.new(params).call
  end

  def routing_key
    'my.custom.routing.key'
  end
end
```

New implementation explicitly emphasizes that "routing key" it is a "message option". Moreover, now we can pass other amqp attributes, like headers
```ruby
class MyJob < ActiveJob::Base
  queue_as :some_name

  message_options routing_key: 'my.custom.routing.key',
                  headers: { 'foo' => 'bar' }

  def perform(params)
     ProcessData.new(params).call
  end
end
```

Procs are also supported
```ruby
class MyJob < ActiveJob::Base
  queue_as :some_name

  message_options routing_key: ->(job) { "my.custom.routing.#{job.arguments.first[:id]}" },
                  headers: { 'foo' => 'bar' }

  def perform(params)
     ProcessData.new(params).call
  end
end
```
Inspired by Sidekiq `sidekiq_options` of [ActiveJob integration](https://github.com/mperham/sidekiq/wiki/Active-Job#customizing-error-handling)