### PR TITLE
Support queue name prefixes

### DIFF
--- a/lib/advanced_sneakers_activejob/active_job_patch.rb
+++ b/lib/advanced_sneakers_activejob/active_job_patch.rb
@@ -33,9 +33,16 @@ module AdvancedSneakersActiveJob
       private
 
       def define_consumer
+        Rails.logger.warn queue_name_without_prefix
+        AdvancedSneakersActiveJob.define_consumer(queue_name: queue_name_without_prefix)
+      end
+
+      def queue_name_without_prefix
         name = queue_name.respond_to?(:call) ? queue_name.call : queue_name
 
-        AdvancedSneakersActiveJob.define_consumer(queue_name: name)
+        return name if queue_name_prefix.blank?
+
+        name.to_s.sub([queue_name_prefix, queue_name_delimiter].join, '')
       end
     end
   end

--- a/spec/apps/with_advanced_sneakers_adapter.rb
+++ b/spec/apps/with_advanced_sneakers_adapter.rb
@@ -11,6 +11,8 @@ require 'advanced/sneakers/activejob'
 class App < Rails::Application
   config.root = __dir__
   config.active_job.queue_adapter = :advanced_sneakers
+  config.active_job.queue_name_prefix = ENV['ACTIVE_JOB_QUEUE_NAME_PREFIX'] if ENV['ACTIVE_JOB_QUEUE_NAME_PREFIX']
+  config.active_job.queue_name_delimiter = ENV['ACTIVE_JOB_QUEUE_NAME_DELIMITER'] if ENV['ACTIVE_JOB_QUEUE_NAME_DELIMITER']
   config.eager_load = true
   config.logger = Logger.new(Rails.root.join('log/rails.log'))
   config.logger.level = :debug

--- a/spec/integration/consumers_spec.rb
+++ b/spec/integration/consumers_spec.rb
@@ -1,35 +1,73 @@
 # frozen_string_literal: true
 
 describe 'Consumers' do
-  subject do
-    in_app_process(adapter: :advanced_sneakers) do
-      class FooJob < ApplicationJob
-        queue_as :baz
-      end
-
-      class BarJob < ApplicationJob
-        queue_as :baz
-      end
-
-      class DynamicQueueJob < ApplicationJob
-        queue_as do
-          'dynamic'
+  context 'when no ActiveJob prefix defined' do
+    subject do
+      in_app_process(adapter: :advanced_sneakers) do
+        class FooJob < ApplicationJob
+          queue_as :baz
         end
+
+        class BarJob < ApplicationJob
+          queue_as :baz
+        end
+
+        class DynamicQueueJob < ApplicationJob
+          queue_as do
+            'dynamic'
+          end
+        end
+
+        AdvancedSneakersActiveJob.configure { |c| c.activejob_workers_strategy = :only }
+
+        Sneakers::Worker::Classes.call.map(&:name)
       end
+    end
 
-      AdvancedSneakersActiveJob.configure { |c| c.activejob_workers_strategy = :only }
-
-      Sneakers::Worker::Classes.call.map(&:name)
+    it 'are defined per queue' do
+      expect(subject.first).to match_array [
+        'AdvancedSneakersActiveJob::DefaultQueueConsumer', # default consumer
+        'AdvancedSneakersActiveJob::MailersQueueConsumer', # action mailer consumer
+        'AdvancedSneakersActiveJob::CustomQueueConsumer', # see CustomQueueJob in spec/apps/app/jobs
+        'AdvancedSneakersActiveJob::BazQueueConsumer', # baz queue consumer for FooJob and BarJob
+        'AdvancedSneakersActiveJob::DynamicQueueConsumer' # dynamic queue consumer for DynamicQueueJob
+      ]
     end
   end
 
-  it 'are defined per queue' do
-    expect(subject.first).to match_array [
-      'AdvancedSneakersActiveJob::DefaultQueueConsumer', # default consumer
-      'AdvancedSneakersActiveJob::MailersQueueConsumer', # action mailer consumer
-      'AdvancedSneakersActiveJob::CustomQueueConsumer', # see CustomQueueJob in spec/apps/app/jobs
-      'AdvancedSneakersActiveJob::BazQueueConsumer', # baz queue consumer for FooJob and BarJob
-      'AdvancedSneakersActiveJob::DynamicQueueConsumer' # dynamic queue consumer for DynamicQueueJob
-    ]
+  context 'when ActiveJob has prefix defined' do
+    subject do
+      r = in_app_process(adapter: :advanced_sneakers, env: { 'ACTIVE_JOB_QUEUE_NAME_PREFIX' => 'custom', 'ACTIVE_JOB_QUEUE_NAME_DELIMITER' => ':' }) do
+        class FooJob < ApplicationJob
+          queue_as :baz
+        end
+
+        class BarJob < ApplicationJob
+          queue_as :baz
+        end
+
+        class DynamicQueueJob < ApplicationJob
+          queue_as do
+            'dynamic'
+          end
+        end
+
+        AdvancedSneakersActiveJob.configure { |c| c.activejob_workers_strategy = :only }
+
+        Sneakers::Worker::Classes.call.map(&:name)
+      end
+      puts r.last
+      r
+    end
+
+    it 'are defined per queue with prefix ignored' do
+      expect(subject.first).to match_array [
+        'AdvancedSneakersActiveJob::DefaultQueueConsumer', # default consumer
+        'AdvancedSneakersActiveJob::MailersQueueConsumer', # action mailer consumer
+        'AdvancedSneakersActiveJob::CustomQueueConsumer', # see CustomQueueJob in spec/apps/app/jobs
+        'AdvancedSneakersActiveJob::BazQueueConsumer', # baz queue consumer for FooJob and BarJob
+        'AdvancedSneakersActiveJob::DynamicQueueConsumer' # dynamic queue consumer for DynamicQueueJob
+      ]
+    end
   end
 end


### PR DESCRIPTION
Fixes error when ActiveJob has queue prefix with delimiter that does not play nice with `String.classify`.

```ruby
Rails.application.config.active_job.queue_name_prefix = 'custom'
Rails.application.config.active_job.queue_name_delimiter = ':'
class ExampleJob < ActiveJob::Base; queue_as :example; end
Traceback (most recent call last):
        3: from (irb):3
        2: from (irb):3:in `rescue in irb_binding'
        1: from (irb):3:in `<class:ExampleJob>'
NameError (wrong constant name Custom:exampleQueueConsumer)
```
Prefix is ignored now for consumer class definition.