### PR TITLE
Respect ActiveJob queue prefix for queues

### DIFF
--- a/lib/advanced_sneakers_activejob/active_job_patch.rb
+++ b/lib/advanced_sneakers_activejob/active_job_patch.rb
@@ -33,15 +33,7 @@ module AdvancedSneakersActiveJob
       private
 
       def define_consumer
-        AdvancedSneakersActiveJob.define_consumer(queue_name: queue_name_without_prefix)
-      end
-
-      def queue_name_without_prefix
-        name = queue_name.respond_to?(:call) ? queue_name.call : queue_name
-
-        return name if queue_name_prefix.blank?
-
-        name.to_s.sub([queue_name_prefix, queue_name_delimiter].join, '')
+        AdvancedSneakersActiveJob.define_consumer(queue_name: new.queue_name)
       end
     end
   end

--- a/lib/advanced_sneakers_activejob/publisher.rb
+++ b/lib/advanced_sneakers_activejob/publisher.rb
@@ -170,9 +170,9 @@ module AdvancedSneakersActiveJob
 
     def delayed_queue_name(delay:)
       [
-        config_delayed_queue_prefix,
-        delay
-      ].join(':')
+        ::ActiveJob::Base.queue_name_prefix,
+        [config_delayed_queue_prefix, delay].join(':')
+      ].compact.join(::ActiveJob::Base.queue_name_delimiter)
     end
 
     def create_delayed_queue_and_binding(queue_name:, delay:)

--- a/lib/advanced_sneakers_activejob/tasks.rb
+++ b/lib/advanced_sneakers_activejob/tasks.rb
@@ -5,7 +5,7 @@ require 'sneakers/tasks'
 task :environment
 
 namespace :sneakers do
-  desc 'Start work for ActiveJob only (set $WORKERS=AdvancedSneakersActiveJob::FooQueueConsumer for processing of :foo queue)'
+  desc 'Start work for ActiveJob only (set $WORKERS=AdvancedSneakersActiveJob::FooConsumer for processing of :foo queue)'
   task :active_job do
     Rake::Task['environment'].invoke
 

--- a/spec/advanced_sneakers_activejob/consumer_name_spec.rb
+++ b/spec/advanced_sneakers_activejob/consumer_name_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe AdvancedSneakersActiveJob, '.consumer_name' do
+  subject { described_class.consumer_name(queue_name: queue_name) }
+
+  {
+    'default' => 'DefaultConsumer',
+    'foo:bar' => 'FooBarConsumer',
+    '_foo ' => 'FooConsumer',
+    'foo.bar.baz' => 'FooBarBazConsumer',
+    'qüeüe' => 'QueueConsumer',
+    '99' => 'Queue99Consumer'
+  }.each do |name, expected_consumer_name|
+    context "when queue name is '#{name}'" do
+      let(:queue_name) { name }
+
+      it { is_expected.to eq expected_consumer_name }
+    end
+  end
+end

--- a/spec/advanced_sneakers_activejob/define_consumer_spec.rb
+++ b/spec/advanced_sneakers_activejob/define_consumer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe AdvancedSneakersActiveJob, '.define_consumer' do
+  context 'when called multiple times with different queue names' do
+    let(:consumer1) { described_class.define_consumer(queue_name: 'unique_queue_1') }
+    let(:consumer2) { described_class.define_consumer(queue_name: 'unique_queue_2') }
+
+    it 'defines consumers per queue' do
+      expect(consumer1).not_to be(consumer2)
+    end
+  end
+
+  context 'when called multiple times with same queue names' do
+    let(:consumer1) { described_class.define_consumer(queue_name: 'non_unique_queue') }
+    let(:consumer2) { described_class.define_consumer(queue_name: 'non_unique_queue') }
+
+    it 'does not define new consumer' do
+      expect(consumer1).to be(consumer2)
+    end
+  end
+end

--- a/spec/integration/consumers_spec.rb
+++ b/spec/integration/consumers_spec.rb
@@ -20,18 +20,20 @@ describe 'Consumers' do
 
         AdvancedSneakersActiveJob.configure { |c| c.activejob_workers_strategy = :only }
 
-        Sneakers::Worker::Classes.call.map(&:name)
+        Sneakers::Worker::Classes.call.map { |consumer| [consumer.name, consumer.queue_name] }.to_h
       end
     end
 
     it 'are defined per queue' do
-      expect(subject.first).to match_array [
-        'AdvancedSneakersActiveJob::DefaultQueueConsumer', # default consumer
-        'AdvancedSneakersActiveJob::MailersQueueConsumer', # action mailer consumer
-        'AdvancedSneakersActiveJob::CustomQueueConsumer', # see CustomQueueJob in spec/apps/app/jobs
-        'AdvancedSneakersActiveJob::BazQueueConsumer', # baz queue consumer for FooJob and BarJob
-        'AdvancedSneakersActiveJob::DynamicQueueConsumer' # dynamic queue consumer for DynamicQueueJob
-      ]
+      expected_consumers = {
+        'AdvancedSneakersActiveJob::DefaultConsumer' => 'default', # default consumer
+        'AdvancedSneakersActiveJob::MailersConsumer' => 'mailers', # action mailer consumer
+        'AdvancedSneakersActiveJob::CustomConsumer' => 'custom', # see CustomQueueJob in spec/apps/app/jobs
+        'AdvancedSneakersActiveJob::BazConsumer' => 'baz', # baz queue consumer for FooJob and BarJob
+        'AdvancedSneakersActiveJob::DynamicConsumer' => 'dynamic' # dynamic queue consumer for DynamicQueueJob
+      }
+
+      expect(subject.first).to eq(expected_consumers)
     end
   end
 
@@ -54,18 +56,20 @@ describe 'Consumers' do
 
         AdvancedSneakersActiveJob.configure { |c| c.activejob_workers_strategy = :only }
 
-        Sneakers::Worker::Classes.call.map(&:name)
+        Sneakers::Worker::Classes.call.map { |consumer| [consumer.name, consumer.queue_name] }.to_h
       end
     end
 
-    it 'are defined per queue with prefix ignored' do
-      expect(subject.first).to match_array [
-        'AdvancedSneakersActiveJob::DefaultQueueConsumer', # default consumer
-        'AdvancedSneakersActiveJob::MailersQueueConsumer', # action mailer consumer
-        'AdvancedSneakersActiveJob::CustomQueueConsumer', # see CustomQueueJob in spec/apps/app/jobs
-        'AdvancedSneakersActiveJob::BazQueueConsumer', # baz queue consumer for FooJob and BarJob
-        'AdvancedSneakersActiveJob::DynamicQueueConsumer' # dynamic queue consumer for DynamicQueueJob
-      ]
+    it 'are defined per queue with prefix ignored in consumer class name' do
+      expected_consumers = {
+        'AdvancedSneakersActiveJob::CustomDefaultConsumer' => 'custom:default', # default consumer
+        'AdvancedSneakersActiveJob::CustomMailersConsumer' => 'custom:mailers', # action mailer consumer
+        'AdvancedSneakersActiveJob::CustomCustomConsumer' => 'custom:custom', # see CustomQueueJob in spec/apps/app/jobs
+        'AdvancedSneakersActiveJob::CustomBazConsumer' => 'custom:baz', # baz queue consumer for FooJob and BarJob
+        'AdvancedSneakersActiveJob::CustomDynamicConsumer' => 'custom:dynamic' # dynamic queue consumer for DynamicQueueJob
+      }
+
+      expect(subject.first).to eq(expected_consumers)
     end
   end
 end


### PR DESCRIPTION
- [x] Improves support of [ActiveJob queue prefix](https://guides.rubyonrails.org/active_job_basics.html#queues) - queues are also defined with prefix
- [x] Uses prefix for delayed queues
- [x] Minor changes in consumers naming  