### PR TITLE
Support custom adapter per job

### DIFF
--- a/lib/advanced_sneakers_activejob/active_job_patch.rb
+++ b/lib/advanced_sneakers_activejob/active_job_patch.rb
@@ -19,21 +19,10 @@ module AdvancedSneakersActiveJob
         end
       end
 
-      def queue_as(*args)
-        super(*args)
-        define_consumer
-      end
-
       def message_options(options)
         raise ArgumentError, 'message_options accepts Hash argument only' unless options.is_a?(Hash)
 
         self.publish_options = options.symbolize_keys
-      end
-
-      private
-
-      def define_consumer
-        AdvancedSneakersActiveJob.define_consumer(queue_name: new.queue_name)
       end
     end
   end

--- a/lib/advanced_sneakers_activejob/railtie.rb
+++ b/lib/advanced_sneakers_activejob/railtie.rb
@@ -12,7 +12,6 @@ module AdvancedSneakersActiveJob
     initializer 'advanced_sneakers_activejob.discover_default_job' do
       ActiveSupport.on_load(:active_job) do
         ActiveJob::Base.include AdvancedSneakersActiveJob::ActiveJobPatch
-        ActiveJob::Base.queue_as # Enforce definition of ActiveJob::Base::Consumer (default queue)
       end
     end
 

--- a/lib/advanced_sneakers_activejob/workers_registry.rb
+++ b/lib/advanced_sneakers_activejob/workers_registry.rb
@@ -57,8 +57,15 @@ module AdvancedSneakersActiveJob
     private
 
     def define_active_job_consumers
-      ([ActiveJob::Base] + ActiveJob::Base.descendants).each do |worker|
+      active_job_classes_with_matching_adapter.each do |worker|
         AdvancedSneakersActiveJob.define_consumer(queue_name: worker.new.queue_name)
+      end
+    end
+
+    def active_job_classes_with_matching_adapter
+      ([ActiveJob::Base] + ActiveJob::Base.descendants).select do |klass|
+        klass.queue_adapter == ::ActiveJob::QueueAdapters::AdvancedSneakersAdapter ||
+          klass.queue_adapter.is_a?(::ActiveJob::QueueAdapters::AdvancedSneakersAdapter)
       end
     end
   end

--- a/spec/advanced_sneakers_activejob/workers_registry/call_spec.rb
+++ b/spec/advanced_sneakers_activejob/workers_registry/call_spec.rb
@@ -9,7 +9,7 @@ describe AdvancedSneakersActiveJob::WorkersRegistry, '#call' do
   let(:other_class) { Class.new }
 
   before do
-    registry << activejob_class
+    allow(registry).to receive(:activejob_workers).and_return([activejob_class])
     registry << other_class
   end
 

--- a/spec/apps/with_inline_adapter.rb
+++ b/spec/apps/with_inline_adapter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'rails'
+require 'active_job/railtie'
+require 'action_mailer/railtie' unless ENV['SKIP_MAILER']
+
+$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)
+require 'advanced/sneakers/activejob'
+
+class App < Rails::Application
+  config.root = __dir__
+  config.active_job.queue_adapter = :inline
+  config.active_job.queue_name_prefix = ENV['ACTIVE_JOB_QUEUE_NAME_PREFIX'] if ENV['ACTIVE_JOB_QUEUE_NAME_PREFIX']
+  config.active_job.queue_name_delimiter = ENV['ACTIVE_JOB_QUEUE_NAME_DELIMITER'] if ENV['ACTIVE_JOB_QUEUE_NAME_DELIMITER']
+  config.eager_load = true
+  config.logger = Logger.new(Rails.root.join('log/rails.log'))
+  config.logger.level = :debug
+  config.action_mailer.delivery_method = :test unless ENV['SKIP_MAILER']
+end
+
+App.initialize!

--- a/spec/integration/consumers_spec.rb
+++ b/spec/integration/consumers_spec.rb
@@ -62,12 +62,17 @@ describe 'Consumers' do
 
     it 'are defined per queue with prefix ignored in consumer class name' do
       expected_consumers = {
-        'AdvancedSneakersActiveJob::CustomDefaultConsumer' => 'custom:default', # default consumer
         'AdvancedSneakersActiveJob::CustomMailersConsumer' => 'custom:mailers', # action mailer consumer
         'AdvancedSneakersActiveJob::CustomCustomConsumer' => 'custom:custom', # see CustomQueueJob in spec/apps/app/jobs
         'AdvancedSneakersActiveJob::CustomBazConsumer' => 'custom:baz', # baz queue consumer for FooJob and BarJob
         'AdvancedSneakersActiveJob::CustomDynamicConsumer' => 'custom:dynamic' # dynamic queue consumer for DynamicQueueJob
       }
+
+      if ActiveJob.gem_version >= Gem::Version.new('6.0') # https://github.com/rails/rails/pull/34376
+        expected_consumers['AdvancedSneakersActiveJob::CustomDefaultConsumer'] = 'custom:default'
+      else
+        expected_consumers['AdvancedSneakersActiveJob::DefaultConsumer'] = 'default'
+      end
 
       expect(subject.first).to eq(expected_consumers)
     end


### PR DESCRIPTION
ActiveJob 5+ [allows to set adapter per job](https://guides.rubyonrails.org/active_job_basics.html#setting-the-backend). So `:advanced_sneakers` should respect this setting. Bonus: `ActiveJob::Base.queue_as` is not monkey-patched
