### PR TITLE
Restore Sneakers::Worker::Classes methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Changes Between 0.2.3 and 0.3
+## Changes Between 0.3.0 and 0.3.1 (unreleased)
+
+### Restore Sneakers::Worker::Classes methods https://github.com/veeqo/advanced-sneakers-activejob/pull/6
+
+## Changes Between 0.2.3 and 0.3.0
 
 This release does not change the observed behavior, but replaces the publisher with completely new implementation.
 

--- a/lib/advanced_sneakers_activejob/workers_registry.rb
+++ b/lib/advanced_sneakers_activejob/workers_registry.rb
@@ -54,6 +54,18 @@ module AdvancedSneakersActiveJob
       @activejob_workers
     end
 
+    def method_missing(method_name, *args, &block)
+      if call.respond_to?(method_name)
+        call.send(method_name, *args, &block)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      call.respond_to?(method_name) || super
+    end
+
     private
 
     def define_active_job_consumers

--- a/spec/advanced_sneakers_activejob/workers_registry/method_missing_spec.rb
+++ b/spec/advanced_sneakers_activejob/workers_registry/method_missing_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe AdvancedSneakersActiveJob::WorkersRegistry do
+  let(:registry) { described_class.new }
+
+  let(:activejob_class) { Class.new(ActiveJob::QueueAdapters::AdvancedSneakersAdapter::JobWrapper) }
+  let(:other_class) { Class.new }
+
+  before do
+    allow(registry).to receive(:activejob_workers).and_return([activejob_class])
+    registry << other_class
+  end
+
+  context 'when supported method is called' do
+    subject { registry.count }
+
+    it { is_expected.to eq 2 }
+  end
+
+  context 'when unsupported method is called' do
+    subject { registry.foobar }
+
+    it 'raises NoMethodError' do
+      expect { subject }.to raise_error(NoMethodError, /undefined method `foobar'/)
+    end
+  end
+end


### PR DESCRIPTION
Originally `Sneakers::Worker::Classes` is an Array object. Since AdvancedSneakersActivejob replaces it with `WorkerRegistry`, methods like `#count`, `#map` and other methods of Array are not working anymore. This commit makes `WorkerRegistry` to proxy missing methods to array of classes to restore ability to call `#count`/`#map`/etc on `Sneakers::Worker::Classes`