### PR TITLE
Add ability to run workers for specified queues

### DIFF
--- a/lib/advanced_sneakers_activejob/support/locate_workers_by_queues.rb
+++ b/lib/advanced_sneakers_activejob/support/locate_workers_by_queues.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module AdvancedSneakersActiveJob
+  module Support
+    class LocateWorkersByQueues
+      def initialize(queues)
+        @queues = queues.uniq.reject(&:blank?)
+        @queues_without_workers = []
+        @workers = []
+      end
+
+      def call
+        detect_workers_for_queues!
+        ensure_all_workers_found!
+
+        @workers
+      end
+
+      private
+
+      def ensure_all_workers_found!
+        return if @queues_without_workers.empty?
+
+        raise("Missing workers for queues: #{@queues_without_workers.join(', ')}")
+      end
+
+      def all_workers
+        @all_workers ||= Sneakers::Worker::Classes.activejob_workers
+      end
+
+      def detect_workers_for_queues!
+        @queues.each do |queue|
+          worker = all_workers.detect { |klass| klass.queue_name == queue }
+
+          if worker
+            @workers << worker
+          else
+            @queues_without_workers << queue
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/advanced_sneakers_activejob/tasks.rb
+++ b/lib/advanced_sneakers_activejob/tasks.rb
@@ -5,9 +5,11 @@ require 'sneakers/tasks'
 task :environment
 
 namespace :sneakers do
-  desc 'Start work for ActiveJob only (set $WORKERS=AdvancedSneakersActiveJob::FooConsumer for processing of :foo queue)'
+  desc 'Start work for ActiveJob only (set $QUEUES=foo,bar.baz for processing of "foo" and "bar.baz" queues)'
   task :active_job do
     Rake::Task['environment'].invoke
+
+    populate_workers_by_queues if ENV['WORKERS'].blank? && ENV['QUEUES'].present?
 
     # Enforsing ActiveJob-only workers
     AdvancedSneakersActiveJob.configure { |c| c.activejob_workers_strategy = :only }
@@ -17,5 +19,15 @@ namespace :sneakers do
     Sneakers.logger.level = Logger::INFO # debug logs are too noizy because of bunny
 
     Rake::Task['sneakers:run'].invoke
+  end
+
+  def populate_workers_by_queues
+    require 'advanced_sneakers_activejob/support/locate_workers_by_queues'
+    ::Rails.application.eager_load!
+
+    queues = ENV['QUEUES'].split(',')
+    workers = AdvancedSneakersActiveJob::Support::LocateWorkersByQueues.new(queues).call
+
+    ENV['WORKERS'] = workers.map(&:name).join(',')
   end
 end

--- a/spec/advanced_sneakers_activejob/support/locate_workers_by_queues_spec.rb
+++ b/spec/advanced_sneakers_activejob/support/locate_workers_by_queues_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'advanced_sneakers_activejob/support/locate_workers_by_queues'
+
+describe AdvancedSneakersActiveJob::Support::LocateWorkersByQueues do
+  subject { locator.call }
+
+  let(:locator) { described_class.new(queues) }
+
+  let(:foo_worker) do
+    Class.new do
+      def self.queue_name
+        'foo'
+      end
+    end
+  end
+
+  let(:bar_worker) do
+    Class.new do
+      def self.queue_name
+        'bar'
+      end
+    end
+  end
+
+  before { allow(Sneakers::Worker::Classes).to receive(:activejob_workers).and_return([foo_worker, bar_worker]) }
+
+  context 'when workers are found for all requested queues' do
+    let(:queues) { %w[foo bar] }
+
+    it { is_expected.to eq([foo_worker, bar_worker]) }
+  end
+
+  context 'when workers are not found for queues' do
+    let(:queues) { %w[foo baz qux] }
+
+    it 'raises error' do
+      expect { subject }.to raise_error(RuntimeError, 'Missing workers for queues: baz, qux')
+    end
+  end
+end


### PR DESCRIPTION
This feature works only for `sneakers:active_job` rake task!

Example:
```sh
QUEUES=foo,bar rake sneakers:active_job
```