### PR TITLE
Allow to run consumers for queues specified with wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ rake sneakers:active_job
 
 Run worker for picked queues of ActiveJob
 ```sh
-rake sneakers:active_job QUEUES=mailers,foo,bar
+QUEUES=mailers,foo,bar rake sneakers:active_job
+```
+
+Wildcards are supported for queues names with "words" (separator is `.`). Algorithm is similar to the way the [topic exchange matches routing keys](https://www.rabbitmq.com/tutorials/tutorial-five-python.html). `*` (star) substitutes for exactly one word. `#` (hash) substitutes for zero or more words
+
+```sh
+QUEUES=mailers,index.*,telemetery.# rake sneakers:active_job
 ```
 
 ## Unrouted messages

--- a/spec/advanced_sneakers_activejob/support/locate_workers_by_queues_spec.rb
+++ b/spec/advanced_sneakers_activejob/support/locate_workers_by_queues_spec.rb
@@ -10,7 +10,7 @@ describe AdvancedSneakersActiveJob::Support::LocateWorkersByQueues do
   let(:foo_worker) do
     Class.new do
       def self.queue_name
-        'foo'
+        'one.foo.two'
       end
     end
   end
@@ -18,24 +18,106 @@ describe AdvancedSneakersActiveJob::Support::LocateWorkersByQueues do
   let(:bar_worker) do
     Class.new do
       def self.queue_name
-        'bar'
+        'one.bar.two'
       end
     end
   end
 
   before { allow(Sneakers::Worker::Classes).to receive(:activejob_workers).and_return([foo_worker, bar_worker]) }
 
-  context 'when workers are found for all requested queues' do
-    let(:queues) { %w[foo bar] }
+  context 'when requested queues do not contain * or # chars' do
+    context 'when workers are found for all requested queues' do
+      let(:queues) { %w[one.foo.two one.bar.two] }
 
-    it { is_expected.to eq([foo_worker, bar_worker]) }
+      it 'returns matching workers' do
+        expect(subject).to eq([foo_worker, bar_worker])
+      end
+    end
+
+    context 'when workers are not found for queues' do
+      let(:queues) { %w[one.foo.two baz qux] }
+
+      it 'raises error' do
+        expect { subject }.to raise_error(RuntimeError, 'Missing workers for queues: baz, qux')
+      end
+    end
   end
 
-  context 'when workers are not found for queues' do
-    let(:queues) { %w[foo baz qux] }
+  context 'when requested queues contain * and do not contain #' do
+    context 'when requested queues match with multiple workers' do
+      let(:queues) { ['one.*.two'] }
 
-    it 'raises error' do
-      expect { subject }.to raise_error(RuntimeError, 'Missing workers for queues: baz, qux')
+      it 'returns matching workers' do
+        expect(subject).to eq([foo_worker, bar_worker])
+      end
+    end
+
+    context 'when requested queues match with one worker' do
+      let(:queues) { ['one.foo.*'] }
+
+      it 'returns matching worker' do
+        expect(subject).to eq([foo_worker])
+      end
+    end
+
+    context 'when workers are not found for queues' do
+      let(:queues) { %w[one.* *.two] }
+
+      it 'raises error' do
+        expect { subject }.to raise_error(RuntimeError, 'Missing workers for queues: one.*, *.two')
+      end
+    end
+  end
+
+  context 'when requested queues contain # and do not contain *' do
+    context 'when requested queues match with multiple workers' do
+      let(:queues) { %w[one.#] }
+
+      it 'returns matching workers' do
+        expect(subject).to eq([foo_worker, bar_worker])
+      end
+    end
+
+    context 'when requested queues match with one worker' do
+      let(:queues) { %w[one.foo.#] }
+
+      it 'returns matching worker' do
+        expect(subject).to eq([foo_worker])
+      end
+    end
+
+    context 'when workers are not found for queues' do
+      let(:queues) { %w[one#] }
+
+      it 'raises error' do
+        expect { subject }.to raise_error(RuntimeError, 'Missing workers for queues: one#')
+      end
+    end
+  end
+
+  context 'when requested queues contain * and #' do
+    context 'when requested queues match with multiple workers' do
+      let(:queues) { %w[one.*.two.#] }
+
+      it 'returns matching workers' do
+        expect(subject).to eq([foo_worker, bar_worker])
+      end
+    end
+
+    context 'when requested queues match with one worker' do
+      let(:queues) { %w[*.foo.#] }
+
+      it 'returns matching worker' do
+        expect(subject).to eq([foo_worker])
+      end
+    end
+
+    context 'when workers are not found for queues' do
+      let(:queues) { %w[on.#] }
+
+      it 'raises error' do
+        expect { subject }.to raise_error(RuntimeError, 'Missing workers for queues: on.#')
+      end
     end
   end
 end


### PR DESCRIPTION
The algorithm is similar to the [topic exchange routing key algorithm](https://www.rabbitmq.com/tutorials/tutorial-five-python.html).

`*` (star) can substitute for exactly one word
`#` (hash) can substitute for zero or more words

Examples:

If we have consumers for queues

- `index.products`
- `index.orders`
- `index.orders.paid`
- `index.orders.paid.visa`
- `cache.orders`

`QUEUES=index.* rake sneakers:active_job`
Will run consumers for queues `index.products` and `index.orders`

`QUEUES=index.*.# rake sneakers:active_job`
Will run consumers for queues `index.products`, `index.orders`, `index.orders.paid`, `index.orders.paid.visa`

`QUEUES=*.* rake sneakers:active_job`
Will run consumers for queues `index.products`, `index.orders`, `cache.orders`

`QUEUES=*.orders rake sneakers:active_job`
Will run consumers for queues `cache.orders`, `index.orders`