### PR TITLE
Drop Railtie initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Changes Between 0.3.4 and 0.3.5 (unreleased)
+
+[Fixed NoMethodError on Rails.application.eager_load! in Rails initializer](https://github.com/veeqo/advanced-sneakers-activejob/pull/11)
+
+```
+NoMethodError: undefined method `message_options' for MyJob:Class
+```
+
 ## Changes Between 0.3.3 and 0.3.4
 
 ### [Support for wildcards to run ActiveJob consumers by queues](https://github.com/veeqo/advanced-sneakers-activejob/pull/10)

--- a/lib/advanced_sneakers_activejob.rb
+++ b/lib/advanced_sneakers_activejob.rb
@@ -21,6 +21,14 @@ require 'advanced_sneakers_activejob/active_job_patch'
 require 'advanced_sneakers_activejob/railtie' if defined?(::Rails::Railtie)
 require 'active_job/queue_adapters/advanced_sneakers_adapter'
 
+ActiveSupport.on_load(:active_job) do
+  ActiveJob::Base.include AdvancedSneakersActiveJob::ActiveJobPatch
+end
+
+ActiveSupport.on_load(:action_mailer) do
+  require 'action_mailer/delivery_job' # Enforce definition of ActionMailer::DeliveryJob::Consumer
+end
+
 # Advanced Sneakers adapter for ActiveJob
 module AdvancedSneakersActiveJob
   class << self

--- a/lib/advanced_sneakers_activejob/railtie.rb
+++ b/lib/advanced_sneakers_activejob/railtie.rb
@@ -3,18 +3,6 @@
 module AdvancedSneakersActiveJob
   # Rails integration
   class Railtie < ::Rails::Railtie
-    initializer 'advanced_sneakers_activejob.discover_mailer_job' do
-      ActiveSupport.on_load(:action_mailer) do
-        require 'action_mailer/delivery_job' # Enforce definition of ActionMailer::DeliveryJob::Consumer
-      end
-    end
-
-    initializer 'advanced_sneakers_activejob.discover_default_job' do
-      ActiveSupport.on_load(:active_job) do
-        ActiveJob::Base.include AdvancedSneakersActiveJob::ActiveJobPatch
-      end
-    end
-
     rake_tasks do
       require 'advanced_sneakers_activejob/tasks'
     end


### PR DESCRIPTION
The Railtie initializer makes the patch to be applied much later than ActiveJob is loaded.
It could lead to a NoMethodError if something unusual happens during Rails application load (like calling `Rails.application.eager_load!` in an initializer)

```
NoMethodError: undefined method `message_options' for MyJob:Class
```