### PR TITLE
Fix deprecation warnings of ruby 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/veeqo/advanced-sneakers-activejob/compare/v0.3.5...HEAD)
-- [#13](https://github.com/veeqo/advanced-sneakers-activejob/pull/13) Use appraisals for Travis matrix
 
 ### Changed
 - [#12](https://github.com/veeqo/advanced-sneakers-activejob/pull/12) Refactor changelog to comply with Keep a Changelog
+- [#13](https://github.com/veeqo/advanced-sneakers-activejob/pull/13) Use appraisals for Travis matrix
+
+### Fixed
+- [#14](https://github.com/veeqo/advanced-sneakers-activejob/pull/14) Fix deprecation warnings of ruby 2.7
 
 
 ## [0.3.5](https://github.com/veeqo/advanced-sneakers-activejob/compare/v0.3.4...v0.3.5) - 2020-06-27

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'rails'

--- a/lib/advanced_sneakers_activejob.rb
+++ b/lib/advanced_sneakers_activejob.rb
@@ -54,11 +54,11 @@ module AdvancedSneakersActiveJob
     end
 
     def publisher
-      @publisher ||= AdvancedSneakersActiveJob::Publisher.new(config.publisher_config)
+      @publisher ||= AdvancedSneakersActiveJob::Publisher.new(**config.publisher_config)
     end
 
     def delayed_publisher
-      @delayed_publisher ||= AdvancedSneakersActiveJob::DelayedPublisher.new(config.publisher_config)
+      @delayed_publisher ||= AdvancedSneakersActiveJob::DelayedPublisher.new(**config.publisher_config)
     end
 
     # Based on ActiveSupport::Inflector#parameterize

--- a/spec/support/child_process_helpers.rb
+++ b/spec/support/child_process_helpers.rb
@@ -47,8 +47,8 @@ module ChildProcessHelpers
     Process.spawn(env, "ruby -r #{app_path}.rb -e 'Marshal.dump(eval(STDIN.read), STDOUT)'", in: read, out: write, err: err)
   end
 
-  def start_sneakers_consumers(*args)
-    in_app_process(*args) do
+  def start_sneakers_consumers(**args)
+    in_app_process(**args) do
       require 'rake'
       require 'sneakers/tasks'
       Rake::Task['sneakers:run'].invoke


### PR DESCRIPTION
Ruby 2.7 deprecates automatic conversion from a hash to keyword arguments