### PR TITLE
Add ability to set AMQP message options per job

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,12 @@ Lint/SuppressedException:
   Exclude:
     - spec/**/*
 
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Metrics/ClassLength:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/veeqo/advanced-sneakers-activejob/compare/v0.3.6...HEAD)
 
+### Added
+- [#15](https://github.com/veeqo/advanced-sneakers-activejob/pull/15) Add ability to set AMQP message options per job
+
 
 ## [0.3.6](https://github.com/veeqo/advanced-sneakers-activejob/compare/v0.3.5...v0.3.6) - 2020-09-18
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Take into accout that **this process is asynchronous**. It means that in case of
 
 ## Custom message options
 
-Advanced sneakers adapter allows to set custom message options (e.g. [routing keys](https://www.rabbitmq.com/tutorials/tutorial-four-ruby.html)).
+Advanced sneakers adapter allows to set [custom message options](http://reference.rubybunny.info/Bunny/Exchange.html#publish-instance_method) (e.g. [routing keys](https://www.rabbitmq.com/tutorials/tutorial-four-ruby.html)) on class-level.
 
 ```ruby
 class MyJob < ActiveJob::Base
@@ -96,6 +96,14 @@ class MyJob < ActiveJob::Base
 end
 ```
 
+And also supports custom message options per job
+```ruby
+MyJob.set(priority: 1, headers: { 'foo' => 'bar' }).perform_later('baz')
+```
+
+Read more about message properties:
+- https://www.rabbitmq.com/publishers.html#message-properties
+- http://reference.rubybunny.info/Bunny/Exchange.html#publish-instance_method
 
 Take into accout that **custom message options are used for publishing only**.
 

--- a/lib/advanced_sneakers_activejob/active_job_patch.rb
+++ b/lib/advanced_sneakers_activejob/active_job_patch.rb
@@ -6,7 +6,7 @@ module AdvancedSneakersActiveJob
 
     included do
       # AMQP message contains metadata which might be helpful for consumer (e.g. job.delivery_info.routing_key)
-      attr_accessor :delivery_info, :headers
+      attr_accessor :delivery_info, :headers, :publish_options
 
       class_attribute :publish_options, instance_accessor: false
     end
@@ -24,6 +24,14 @@ module AdvancedSneakersActiveJob
 
         self.publish_options = options.symbolize_keys
       end
+    end
+
+    def enqueue(options = {})
+      # Since ActiveJob v5 :priority option is supported natively https://github.com/rails/rails/pull/19425
+      # publish_options holds its own :priority to "backport" priority feature to ActiveJob v4
+      self.publish_options = options.except(:wait, :wait_until, :queue)
+
+      super
     end
   end
 end


### PR DESCRIPTION
ActiveJob supports custom options per message:

```ruby
GuestsCleanupJob.set(wait: 1.hour).perform_later(guest)
```

This change adds ability to set AMQP message properties with the same interface:

```ruby
GuestsCleanupJob.set(wait: 1.hour, headers: { 'foo' => 'bar' }).perform_later(guest)
```

[The list of supported options besides `headers`](http://reference.rubybunny.info/Bunny/Exchange.html#publish-instance_method)

The AdvancedSneakersActiveJob already has support to set custom message option on class level. In case of ad-hoc message properties, they are deep-merged on top of class-level ones.

```ruby
class GuestCleanupJob
  message_options app_id: 'My app', headers: { 'baz' => 'qux' }
end

GuestsCleanupJob.set(app_id: 'Other app', headers: { 'foo' => 'bar' }).perform_later(guest)
# published with message properties {app_id: 'Other app', headers: { 'foo' => 'bar', 'bar' => 'qux' }}
```

Since v5 [ActiveJob supports job priority natively](https://github.com/rails/rails/pull/19425). This change also make it work with Sneakers and "backports" this feature to ActiveJob v4. In order to have priorities to work with RabbitMQ, set queue options in configuration:

```ruby
AdvancedSneakersActiveJob.configure do |config|
  config.sneakers = {
    queue_options: {
      arguments: { 'x-max-priority' => 3 }
    }
  }
end
```