### PR TITLE
Switch to bunny-publisher 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/veeqo/advanced-sneakers-activejob/compare/v0.4.0...HEAD)
 
+### Changed
+- [#16](https://github.com/veeqo/advanced-sneakers-activejob/pull/16) Switch to bunny-publisher v0.2 (drops republish connection)
 
 ## [0.4.0](https://github.com/veeqo/advanced-sneakers-activejob/compare/v0.3.6...v0.4.0) - 2020-11-17
 

--- a/README.md
+++ b/README.md
@@ -181,9 +181,6 @@ AdvancedSneakersActiveJob.configure do |config|
 
   # Connection for publisher (fallbacks to connection of consumers)
   config.publish_connection = Bunny.new('CUSTOM_URL', with: { other: 'options' })
-
-  # Unrouted messages republish requires extra connection and will try to "clone" publish_connection unless it is provided
-  config.republish_connection = Bunny.new('CUSTOM_URL', with: { other: 'options' })
 end
 ```
 

--- a/advanced-sneakers-activejob.gemspec
+++ b/advanced-sneakers-activejob.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activejob', '>= 4.2'
-  spec.add_dependency 'bunny-publisher', '~> 0.1'
+  spec.add_dependency 'bunny-publisher', '~> 0.2.0'
   spec.add_dependency 'sneakers', '~> 2.7'
 
   spec.add_development_dependency 'appraisal', '~> 2.3.0'

--- a/lib/advanced_sneakers_activejob/configuration.rb
+++ b/lib/advanced_sneakers_activejob/configuration.rb
@@ -18,7 +18,10 @@ module AdvancedSneakersActiveJob
     config_accessor(:retry_delay_proc) { ->(count) { AdvancedSneakersActiveJob::EXPONENTIAL_BACKOFF[count] } } # seconds
 
     config_accessor(:publish_connection)
-    config_accessor(:republish_connection)
+
+    def republish_connection=(_)
+      ActiveSupport::Deprecation.warn('Republish connection is not used for bunny-publisher v0.2+')
+    end
 
     def sneakers
       custom_config = DEFAULT_SNEAKERS_CONFIG.deep_merge(config.sneakers || {})
@@ -35,7 +38,7 @@ module AdvancedSneakersActiveJob
     end
 
     def publisher_config
-      sneakers.merge(publish_connection: publish_connection, republish_connection: republish_connection)
+      sneakers.merge(publish_connection: publish_connection)
     end
   end
 end

--- a/lib/advanced_sneakers_activejob/publisher.rb
+++ b/lib/advanced_sneakers_activejob/publisher.rb
@@ -14,9 +14,9 @@ module AdvancedSneakersActiveJob
 
     private
 
-    def log_message(publisher, message, options = {})
+    def log_message
       logger.debug do
-        "Publishing <#{message}> to [#{publisher.exchange.name}] with routing_key [#{options[:routing_key]}]"
+        "Publishing <#{message}> to [#{@exchange_name}] with routing_key [#{message_options[:routing_key]}]"
       end
     end
 


### PR DESCRIPTION
`bunny-publisher` v0.2 has breaking change in callbacks and it also drops extra connection for re-publish of unrouted messages by mandatory publisher https://github.com/veeqo/bunny-publisher/pull/9

It also provides better error handling for network issues when bunny is capable to recover the connection https://github.com/veeqo/bunny-publisher/pull/10