### PR TITLE
Actualize rubies and activejob

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,16 +20,22 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5.8
-          - 2.6.6
-          - 2.7.1
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
         gemfile:
           - gemfiles/activejob_4.2.x.gemfile
           - gemfiles/activejob_5.2.x.gemfile
           - gemfiles/activejob_6.0.x.gemfile
+          - gemfiles/activejob_6.1.x.gemfile
         exclude:
-          - ruby: 2.7.1
+          - ruby: 2.7
             gemfile: gemfiles/activejob_4.2.x.gemfile
+          - ruby: 3.0
+            gemfile: gemfiles/activejob_4.2.x.gemfile
+          - ruby: 3.0
+            gemfile: gemfiles/activejob_5.2.x.gemfile
 
     steps:
     - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/veeqo/advanced-sneakers-activejob/compare/v0.5.0...HEAD)
 
+### Added
+- [#24](https://github.com/veeqo/advanced-sneakers-activejob/pull/24) Test with ruby 3 and ActiveJob v6.1
+
 ### Changed
 - [#22](https://github.com/veeqo/advanced-sneakers-activejob/pull/22) Migrate from Travis to Github Actions
 


### PR DESCRIPTION
- Test with ruby 3 and ActiveJob v6.1
- Do not specify minor ruby versions in Github Actions to make it ues most recent ones