### PR TITLE
Make log level to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - [#24](https://github.com/veeqo/advanced-sneakers-activejob/pull/24) Test with ruby 3 and ActiveJob v6.1
+- [#26](https://github.com/veeqo/advanced-sneakers-activejob/pull/26) Make log level to be configurable
 
 ### Changed
 - [#22](https://github.com/veeqo/advanced-sneakers-activejob/pull/22) Migrate from Travis to Github Actions

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ AdvancedSneakersActiveJob.configure do |config|
 
   # Connection for publisher (fallbacks to connection of consumers)
   config.publish_connection = Bunny.new('CUSTOM_URL', with: { other: 'options' })
+
+  # Log level of "rake sneakers:active_job" output
+  config.log_level = :info
 end
 ```
 

--- a/lib/advanced_sneakers_activejob/configuration.rb
+++ b/lib/advanced_sneakers_activejob/configuration.rb
@@ -16,6 +16,7 @@ module AdvancedSneakersActiveJob
     config_accessor(:delay_proc) { ->(timestamp) { (timestamp - Time.now.to_f).round } } # seconds
     config_accessor(:delayed_queue_prefix) { 'delayed' }
     config_accessor(:retry_delay_proc) { ->(count) { AdvancedSneakersActiveJob::EXPONENTIAL_BACKOFF[count] } } # seconds
+    config_accessor(:log_level) { :info } # debug logs are too noizy because of Bunny
 
     config_accessor(:publish_connection)
 

--- a/lib/advanced_sneakers_activejob/tasks.rb
+++ b/lib/advanced_sneakers_activejob/tasks.rb
@@ -16,7 +16,7 @@ namespace :sneakers do
 
     Sneakers.configure(AdvancedSneakersActiveJob.config.sneakers)
 
-    Sneakers.logger.level = Logger::INFO # debug logs are too noizy because of bunny
+    Sneakers.logger.level = AdvancedSneakersActiveJob.config.log_level
 
     Rake::Task['sneakers:run'].invoke
   end


### PR DESCRIPTION
Now log level of `rake sneakers:active_job` task to be configurable

```ruby
AdvancedSneakersActiveJob.configure do |config|
  config.log_level = :debug
end
```

