### PR TITLE
Replace ActiveSupport::Configurable with class_attribute

### DIFF
--- a/lib/advanced_sneakers_activejob/configuration.rb
+++ b/lib/advanced_sneakers_activejob/configuration.rb
@@ -4,28 +4,28 @@ module AdvancedSneakersActiveJob
   # Advanced Sneakers adapter allows to patch Sneakers with custom configuration.
   # It is useful when already have Sneakers workers running and you want to run ActiveJob Sneakers process with another options.
   class Configuration
-    include ActiveSupport::Configurable
-
     DEFAULT_SNEAKERS_CONFIG = {
       exchange: 'activejob',
       handler: AdvancedSneakersActiveJob::Handler
     }.freeze
 
-    config_accessor(:handle_unrouted_messages) { true } # create queue/binding and re-publish if message is unrouted
-    config_accessor(:activejob_workers_strategy) { :include } # [:include, :exclude, :only]
-    config_accessor(:delay_proc) { ->(timestamp) { (timestamp - Time.now.to_f).round } } # seconds
-    config_accessor(:delayed_queue_prefix) { 'delayed' }
-    config_accessor(:retry_delay_proc) { ->(count) { AdvancedSneakersActiveJob::EXPONENTIAL_BACKOFF[count] } } # seconds
-    config_accessor(:log_level) { :info } # debug logs are too noizy because of Bunny
+    class_attribute :handle_unrouted_messages, default: true # create queue/binding and re-publish if message is unrouted
+    class_attribute :activejob_workers_strategy, default: :include # [:include, :exclude, :only]
+    class_attribute :delay_proc, default: ->(timestamp) { (timestamp - Time.now.to_f).round } # seconds
+    class_attribute :delayed_queue_prefix, default: 'delayed'
+    class_attribute :retry_delay_proc, default: ->(count) { AdvancedSneakersActiveJob::EXPONENTIAL_BACKOFF[count] } # seconds
+    class_attribute :log_level, default: :info # debug logs are too noizy because of Bunny
 
-    config_accessor(:publish_connection)
+    class_attribute :publish_connection, default: nil
+
+    class_attribute :sneakers_config, default: {}
 
     def republish_connection=(_)
       ActiveSupport::Deprecation.warn('Republish connection is not used for bunny-publisher v0.2+')
     end
 
     def sneakers
-      custom_config = DEFAULT_SNEAKERS_CONFIG.deep_merge(config.sneakers || {})
+      custom_config = DEFAULT_SNEAKERS_CONFIG.deep_merge(sneakers_config || {})
 
       if custom_config[:amqp].present? & custom_config[:vhost].nil?
         custom_config[:vhost] = AMQ::Settings.parse_amqp_url(custom_config[:amqp]).fetch(:vhost, '/')
@@ -35,7 +35,7 @@ module AdvancedSneakersActiveJob
     end
 
     def sneakers=(custom)
-      config.sneakers = custom
+      self.sneakers_config = custom
     end
 
     def publisher_config

--- a/spec/support/configuration_helpers.rb
+++ b/spec/support/configuration_helpers.rb
@@ -3,7 +3,7 @@
 RSpec.configure do |config|
   # This tag temporarily sets requested configuration and restores previuos values after test run
   config.around :each, :with_config do |ex|
-    config = AdvancedSneakersActiveJob.config.config
+    config = AdvancedSneakersActiveJob.config
     was = {}
 
     ex.metadata.fetch(:with_config).each do |key, value|


### PR DESCRIPTION
ActiveSupport::Configurable is deprecated without replacement and will be removed in Rails 8.2. Emulate the previous behavior with class_attribute defaults.

- Convert each config_accessor into class_attribute with a default value
- Back the custom sneakers reader/writer with a sneakers_config attribute (previously stored in the internal Configurable `config` object)
- Update the :with_config spec helper to operate on the Configuration instance directly instead of the removed `.config` proxy